### PR TITLE
Update the runtime version from 48 to 50, and more

### DIFF
--- a/io.github.nokse22.inspector.json
+++ b/io.github.nokse22.inspector.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.nokse22.inspector",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "48",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
     "command" : "inspector",
     "finish-args" : [
@@ -10,17 +10,6 @@
         "--device=dri",
         "--socket=wayland",
         "--talk-name=org.freedesktop.Flatpak"
-    ],
-    "cleanup" : [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
     ],
     "modules" : [
     	{


### PR DESCRIPTION
- Update the runtime version to 50
- Drop ineffective cleanup commands